### PR TITLE
Apply protolint codestyle in discount.proto

### DIFF
--- a/challenges/pt-br/new-backend-challenge/discount.proto
+++ b/challenges/pt-br/new-backend-challenge/discount.proto
@@ -1,18 +1,20 @@
 syntax = "proto3";
 
 package discount;
+option go_package = "/pkg/discountpb";
 
-// Service that return mocked discount percentage.
+// Service that return mocked discount percentage
 service Discount {
   rpc GetDiscount(GetDiscountRequest) returns (GetDiscountResponse) {}
 }
 
-// productID used to represent a product. Ilustrative only.
+// product_id used to represent a product. Ilustrative only.
 message GetDiscountRequest {
-  int32 productID = 1;
+  int32 product_id = 1;
 }
 
 // The discount percentage is a fixed value.
 message GetDiscountResponse {
   float percentage = 1;
 }
+

--- a/challenges/pt-br/new-backend-challenge/discount.proto
+++ b/challenges/pt-br/new-backend-challenge/discount.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 package discount;
-option go_package = "/pkg/discountpb";
 
 // Service that return mocked discount percentage
 service Discount {


### PR DESCRIPTION
**O que faz ?**

Aplica `protolint` no arquivo `discount.proto` para forçar um style guide.